### PR TITLE
Re-order comments for hoz/vert margins

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -17,13 +17,13 @@
 %\setlength{\rightbarwidth}{0.25\paperwidth}
 
 %% Setting the column margins
-% Horizontal margin
-%\setlength{\columnmarginvertical}{0.05\paperheight}
 % Vertical margin
+%\setlength{\columnmarginvertical}{0.05\paperheight}
+% Horizontal margin
 %\setlength{\columnmarginhorizontal}{0.05\paperheight}
-% Horizontal margin for the main column
-%\setlength{\maincolumnmarginvertical}{0.15\paperheight}
 % Vertical margin for the main column
+%\setlength{\maincolumnmarginvertical}{0.15\paperheight}
+% Horizontal margin for the main column
 %\setlength{\maincolumnmarginhorizontal}{0.15\paperheight}
 
 %% Changing font sizes


### PR DESCRIPTION
These comments appear to be in the wrong order, i.e., not matching
the instructions that immediately follow them. Swap them around to
match up.